### PR TITLE
jest dev dependencies and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "gulp bundle",
     "clean": "gulp clean",
-    "test": "gulp test"
+    "test": "jest"
   },
   "dependencies": {
     "@microsoft/sp-core-library": "1.10.0",
@@ -40,8 +40,60 @@
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
+    "@types/enzyme": "3.1.15",
+    "@types/jest": "22.2.3",
     "@types/mocha": "2.2.38",
+    "@types/sinon": "5.0.7",
     "ajv": "~5.2.2",
-    "gulp": "~3.9.1"
+    "enzyme": "3.8.0",
+    "enzyme-adapter-react-16": "1.7.1",
+    "gulp": "~3.9.1",
+    "handlebars": "^4.7.7",
+    "identity-obj-proxy": "3.0.0",
+    "jest": "22.4.3",
+    "jest-junit": "5.2.0",
+    "react-test-renderer": "16.6.3",
+    "sinon": "5.0.7",
+    "ts-jest": "22.4.5"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "testMatch": [
+      "**/src/**/*.test.+(ts|tsx|js)"
+    ],
+    "collectCoverage": true,
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "cobertura"
+    ],
+    "coverageDirectory": "<rootDir>/jest",
+    "moduleNameMapper": {
+      "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+      "^office-ui-fabric-react/lib/(.*)$": "office-ui-fabric-react/lib-commonjs/$1"
+    },
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
+  },
+  "jest-junit": {
+    "output": "./jest/summary-jest-junit.xml"
   }
 }

--- a/src/webparts/reactMyGroups/components/ListLayout/ListLayout.test.tsx
+++ b/src/webparts/reactMyGroups/components/ListLayout/ListLayout.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { configure, mount, ReactWrapper } from 'enzyme';
+import {  ISize } from 'office-ui-fabric-react/lib/Utilities';
+import * as Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+
+import { ListLayout } from './ListLayout';
+
+describe('List Layout basic render test', () => {
+
+  it('should render even if empty', () => {
+    var reactComponent = mount(React.createElement(
+        ListLayout,
+        {
+          items: [],
+          onRenderListItem: (item: any, finalSize: ISize, isCompact: boolean) => (<div></div>)
+        }
+    ));
+    
+    const element = reactComponent.find("FocusZone");
+    expect(element.length).toBeGreaterThan(0);
+
+    reactComponent.unmount();
+  });
+});
+


### PR DESCRIPTION
the main thing to note is that office-ui-fabric-react will break any tests it's part of with a "SyntaxError: Unexpected token export" message, adding `"^office-ui-fabric-react/lib/(.*)$": "office-ui-fabric-react/lib-commonjs/$1"` moduleNameMapper gets around that.